### PR TITLE
Bump matrix-react-test-utils to be react16 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1"
   },
-  "dependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+  "peerDependencies": {
+    "react": "^15.6.1 || ^16.0.0",
+    "react-dom": "^15.6.1 || ^16.0.0"
   }
 }


### PR DESCRIPTION
Backwards compatible with current (react15) react-sdk and riot-web develop branches

Will need releasing to npm to deps can be bumped in react16 branches of react-sdk and riot-web

Signed-off-by: Michael Telatynski 7t3chguy@gmail.com